### PR TITLE
Use serde_json::Value to order keys

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,64 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'serde_canonical'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=serde_canonical"
+                ],
+                "filter": {
+                    "name": "serde_canonical",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'serde_canonical'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=serde_canonical",
+                    "--package=serde_canonical"
+                ],
+                "filter": {
+                    "name": "serde_canonical",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'serde_canonical'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=serde_canonical",
+                    "--package=serde_canonical",
+                ],
+                "filter": {
+                    "name": "serde_canonical",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/canonical_value.rs
+++ b/src/canonical_value.rs
@@ -1,0 +1,72 @@
+use serde_json::value::Value;
+use std::fmt::{self, Debug};
+use std::{io, str};
+
+pub struct CanonicalValue {
+    Value: Value,
+}
+
+impl Debug for CanonicalValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self.Value {
+            Value::Null => formatter.debug_tuple("Null").finish(),
+            Value::Bool(v) => formatter.debug_tuple("Bool").field(&v).finish(),
+            Value::Number(ref v) => Debug::fmt(v, formatter),
+            Value::String(ref v) => formatter.debug_tuple("String").field(v).finish(),
+            Value::Array(ref v) => formatter.debug_tuple("Array").field(v).finish(),
+            Value::Object(ref v) => formatter.debug_tuple("Object").field(v).finish(),
+        }
+    }
+}
+
+
+struct WriterFormatter<'a, 'b: 'a> {
+    inner: &'a mut fmt::Formatter<'b>,
+}
+
+impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        fn io_error<E>(_: E) -> io::Error {
+            io::Error::new(io::ErrorKind::Other, "fmt error")
+        }
+        let s = str::from_utf8(buf).map_err(io_error)?;
+        self.inner.write_str(s).map_err(io_error)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl fmt::Display for CanonicalValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut wr = WriterFormatter { inner: f };
+        super::ser::to_writer(&mut wr, self).map_err(|_| fmt::Error)
+    }
+}
+
+impl serde::Serialize for CanonicalValue {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        match self.Value {
+            Value::Null => serializer.serialize_unit(),
+            Value::Bool(b) => serializer.serialize_bool(b),
+            Value::Number(ref n) => n.serialize(serializer),
+            Value::String(ref s) => serializer.serialize_str(s),
+            Value::Array(ref v) => v.serialize(serializer),
+            Value::Object(ref m) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(m.len()))?;
+                for (k, v) in m {
+                    map.serialize_key(k)?;
+                    map.serialize_value(v)?;
+                }
+                map.end()
+            }
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,18 @@ impl From<io::Error> for Error {
     }
 }
 
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Error {
+        use serde_json::error::Category;
+        match err.classify() {
+            Category::Io => Error::Io(err.into()),
+            Category::Syntax | Category::Data | Category::Eof => {
+                Error::Custom(String::from(format!("{}", err)))
+            }
+        }
+    }
+}
+
 impl serde::ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         Error::Custom(msg.to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//#![cfg_attr(test, deny(warnings))]
+#![cfg_attr(test, deny(warnings))]
 #![warn(rust_2018_idioms)]
 
 pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,32 @@
-
 extern crate serde_canonical;
 extern crate serde_json;
 
 use std::{env, fs, path};
 
-const ARG_PANIC_MESSAGE :&str = "The first argument is the input JSON, and the second is an optional output file.";
+const ARG_PANIC_MESSAGE: &str =
+    "The first argument is the input JSON, and the second is an optional output file.";
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-
+    let input = &args[1];
+    let input = fs::File::open(path::Path::new(input)).expect("cannot open input file");
+    let res: serde_json::Value =
+        serde_json::from_reader(input).expect("cannot deserialize input file");
     match args.len() {
         2 => {
-            let input = &args[1];
-            let input = fs::File::open(path::Path::new(input)).expect("cannot open input file");
-            let res: serde_json::Value = serde_json::from_reader(input).expect("cannot deserialize input file");
-            println!("{}", serde_canonical::ser::to_string(&res).expect("cannot write canonical JSON"));
-        },
-        3 => {
-            let input = &args[1];
-            let output = &args[2];
 
-            let input = fs::File::open(path::Path::new(input)).expect("cannot open input file");
-            let mut output = fs::File::create(path::Path::new(output)).expect("cannot create or open output file");
-            let res: serde_json::Value = serde_json::from_reader(input).expect("cannot deserialize input file");
-            serde_canonical::ser::to_writer(&mut output, &res).expect("cannot write canonical JSON");
-        },
-        _ => panic!(ARG_PANIC_MESSAGE)
+            println!(
+                "{}",
+                serde_canonical::ser::to_string(&res).expect("cannot write canonical JSON")
+            );
+        }
+        3 => {
+            let output = &args[2];
+            let mut output = fs::File::create(path::Path::new(output))
+                .expect("cannot create or open output file");
+            serde_canonical::ser::to_writer(&mut output, &res)
+                .expect("cannot write canonical JSON");
+        }
+        _ => panic!(ARG_PANIC_MESSAGE),
     };
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,7 @@
-use crate::error::Error;
-use crate::ser::to_string;
+use crate::{error::Error, ser::to_string};
 use serde_derive::*;
 use serde_json::Value;
-use std::{f32, i16, i32, i64, i8, u16, u32, u64, u8};
+use std::{i16, i32, i64, i8, u16, u32, u64, u8};
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -418,26 +418,6 @@ fn write_newtype_struct() {
     assert_encode_ok(&[(outer, r#"{"outer":{"inner":123}}"#)]);
 }
 
-// TODO - Radu M
-// should the serializer error out on unsorted structs, or should it sort them?
-#[test]
-fn write_unsorted_struct() {
-    #[derive(Serialize, PartialEq, Debug)]
-    struct UnsortedStruct {
-        z: i64,
-        a: i64,
-    };
-
-    #[derive(Serialize, PartialEq, Debug)]
-    enum UnsortedEnum {
-        Boo { z: i64, a: i64 },
-    };
-
-    assert_encode_err(UnsortedStruct { z: 1, a: 2 });
-
-    assert_encode_err(&UnsortedEnum::Boo { z: 1, a: 2 });
-}
-
 #[test]
 fn write_struct() {
     #[derive(Serialize)]
@@ -451,7 +431,7 @@ fn write_struct() {
         seq: vec!["a", "b"],
     };
     let expected = r#"{"int":1,"seq":["a","b"]}"#;
-    assert_encode(&test, expected);    
+    assert_encode(&test, expected);
 }
 
 #[test]
@@ -462,13 +442,10 @@ fn write_struct_ordered() {
         a: u32,
     }
 
-    let test = Test {
-        b: 2,
-        a: 1,
-    };
+    let test = Test { b: 2, a: 1 };
 
     let expected = r#"{"a":1,"b":2}"#;
-    assert_encode(&test, expected);    
+    assert_encode(&test, expected);
 }
 
 #[test]


### PR DESCRIPTION
This PR uses `serde_json::Value` to sort the object keys.

The main temporary downside of this approach is that non-finite `float` values are encoded as `null`, as opposed to erroring out - this will be fixed in a future PR - the grounds for the fix are already in place, but currently unused (see the `canonical_value` module).