### PR TITLE
Use CanonicalValue

### DIFF
--- a/src/canonical_value.rs
+++ b/src/canonical_value.rs
@@ -1,50 +1,10 @@
-use serde_json::value::Value;
-use std::fmt::{self, Debug};
-use std::{io, str};
-
+use super::error::Error;
+use serde::Serialize;
+use serde_json::value::*;
+use std::io::Cursor;
 
 pub struct CanonicalValue {
     value: Value,
-}
-
-impl Debug for CanonicalValue {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.value {
-            Value::Null => formatter.debug_tuple("Null").finish(),
-            Value::Bool(v) => formatter.debug_tuple("Bool").field(&v).finish(),
-            Value::Number(ref v) => Debug::fmt(v, formatter),
-            Value::String(ref v) => formatter.debug_tuple("String").field(v).finish(),
-            Value::Array(ref v) => formatter.debug_tuple("Array").field(v).finish(),
-            Value::Object(ref v) => formatter.debug_tuple("Object").field(v).finish(),
-        }
-    }
-}
-
-
-struct WriterFormatter<'a, 'b: 'a> {
-    inner: &'a mut fmt::Formatter<'b>,
-}
-
-impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        fn io_error<E>(_: E) -> io::Error {
-            io::Error::new(io::ErrorKind::Other, "fmt error")
-        }
-        let s = str::from_utf8(buf).map_err(io_error)?;
-        self.inner.write_str(s).map_err(io_error)?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-impl fmt::Display for CanonicalValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut wr = WriterFormatter { inner: f };
-        super::ser::to_writer(&mut wr, self).map_err(|_| fmt::Error)
-    }
 }
 
 impl serde::Serialize for CanonicalValue {
@@ -72,3 +32,23 @@ impl serde::Serialize for CanonicalValue {
     }
 }
 
+
+pub fn to_value<T>(value: T) -> Result<CanonicalValue, Error>
+where
+    T: Serialize,
+{
+    ensure_canonical(&value)?;
+    let val = serde_json::to_value(value)?;
+    Ok(CanonicalValue { value: val })
+}
+
+fn ensure_canonical<T>(value: &T) -> Result<(), Error>
+where
+    T: serde::Serialize,
+    T: ?Sized,
+{
+    let c = Cursor::new(Vec::new());
+    let mut ser = super::ser::Serializer::new(c);
+    value.serialize(&mut ser)?;
+    Ok(())
+}

--- a/src/canonical_value.rs
+++ b/src/canonical_value.rs
@@ -2,13 +2,14 @@ use serde_json::value::Value;
 use std::fmt::{self, Debug};
 use std::{io, str};
 
+
 pub struct CanonicalValue {
-    Value: Value,
+    value: Value,
 }
 
 impl Debug for CanonicalValue {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match self.Value {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.value {
             Value::Null => formatter.debug_tuple("Null").finish(),
             Value::Bool(v) => formatter.debug_tuple("Bool").field(&v).finish(),
             Value::Number(ref v) => Debug::fmt(v, formatter),
@@ -40,7 +41,7 @@ impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
 }
 
 impl fmt::Display for CanonicalValue {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut wr = WriterFormatter { inner: f };
         super::ser::to_writer(&mut wr, self).map_err(|_| fmt::Error)
     }
@@ -52,7 +53,7 @@ impl serde::Serialize for CanonicalValue {
     where
         S: ::serde::Serializer,
     {
-        match self.Value {
+        match self.value {
             Value::Null => serializer.serialize_unit(),
             Value::Bool(b) => serializer.serialize_bool(b),
             Value::Number(ref n) => n.serialize(serializer),
@@ -70,3 +71,4 @@ impl serde::Serialize for CanonicalValue {
         }
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod error;
 pub mod ser;
+pub mod canonical_value;
 
 #[cfg(test)]
 mod tests;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -11,7 +11,7 @@ where
     W: io::Write,
 {
     let mut ser = Serializer::new(writer);
-    serde_json::to_value(value)?.serialize(&mut ser)?;
+    super::canonical_value::to_value(value)?.serialize(&mut ser)?;
     Ok(())
 }
 


### PR DESCRIPTION
This is the first iteration of the serializer that passes all tests.

It implements a `CanonicalValue` struct that is currently a wrapper over `serde_json::Value` (but could evolve to include all the serialization logic, and avoid multiple passes over the same object before serializing).